### PR TITLE
refactor: simplify API, CLI, paths, and wallpaper setting

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,3 @@
-use crate::cli::Args;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -9,45 +8,55 @@ pub struct Post {
     pub rating: String,
 }
 
-pub fn fetch(args: &Args) -> Result<Post, String> {
-    let url = if let Some(id) = args.id {
-        if args.verbose {
-            println!("→ Fetching post ID {}", id);
+pub fn fetch(id: Option<u64>, nsfw: bool, verbose: bool) -> Result<Post, String> {
+    let url = match id {
+        Some(i) => {
+            if verbose {
+                println!("→ Fetching post ID {}", i);
+            }
+            format!("https://konachan.net/post.json?tags=id%3A{}", i)
         }
-        format!("https://konachan.net/post.json?tags=id%3A{}", id)
-    } else {
-        if args.verbose {
-            let rating = if args.nsfw { "explicit" } else { "safe" };
-            println!("→ Fetching random {} post", rating);
+        None => {
+            if verbose {
+                println!(
+                    "→ Fetching random {} post",
+                    if nsfw { "explicit" } else { "safe" }
+                );
+            }
+            format!(
+                "https://konachan.net/post.json?tags=rating%3A{}%20order%3Arandom&limit=1",
+                if nsfw { "explicit" } else { "safe" }
+            )
         }
-        if args.nsfw {
-            "https://konachan.net/post.json?tags=rating%3Aexplicit%20order%3Arandom&limit=1"
-        } else {
-            "https://konachan.net/post.json?tags=rating%3Asafe%20order%3Arandom&limit=1"
-        }
-        .to_string()
     };
 
-    let mut resp = ureq::get(&url)
+    let buf = ureq::get(&url)
         .header("User-Agent", "parch")
         .call()
         .map_err(|e| format!("Request failed: {}", e))?
-        .into_body();
+        .into_body()
+        .read_to_vec()
+        .map_err(|e| e.to_string())?;
 
-    let buf = resp.read_to_vec().map_err(|e| e.to_string())?;
-
-    let posts: Vec<Post> = serde_json::from_slice(&buf).map_err(|e| e.to_string())?;
-
-    posts
+    serde_json::from_slice::<Vec<Post>>(&buf)
+        .map_err(|e| e.to_string())?
         .into_iter()
         .next()
         .ok_or_else(|| "No post found".to_string())
 }
 
-pub fn image_url(post: &Post) -> Result<&str, String> {
-    post.file_url
+pub fn image_url(post: &Post) -> Result<String, String> {
+    let url = post
+        .file_url
         .as_deref()
         .or(post.large_file_url.as_deref())
-        .map(|url| url.strip_prefix("//").unwrap_or(url))
-        .ok_or_else(|| "No image URL".to_string())
+        .ok_or("No image URL")?;
+
+    Ok(if url.starts_with("//") {
+        format!("https:{}", url)
+    } else if !url.starts_with("http") {
+        format!("https://{}", url)
+    } else {
+        url.to_string()
+    })
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,9 +1,12 @@
+use crate::paths::parch_dir;
 use std::fs::{File, create_dir_all};
 use std::io::copy;
 use std::path::PathBuf;
 
 pub fn save(id: u64, url: &str, nsfw: bool, verbose: bool) -> Result<PathBuf, String> {
-    let dir = dir_path(nsfw)?;
+    let dir = parch_dir(nsfw)?;
+    create_dir_all(&dir).map_err(|e| e.to_string())?;
+
     let ext = url
         .rsplit('/')
         .next()
@@ -15,8 +18,11 @@ pub fn save(id: u64, url: &str, nsfw: bool, verbose: bool) -> Result<PathBuf, St
     let dest = dir.join(format!("{}.{}", id, ext));
 
     if verbose {
-        println!("→ Downloading from: {}", url);
-        println!("→ Saving to: {}", dest.display());
+        println!(
+            "→ Downloading from: {}\n→ Saving to: {}",
+            url,
+            dest.display()
+        );
     }
 
     let resp = ureq::get(url)
@@ -30,35 +36,9 @@ pub fn save(id: u64, url: &str, nsfw: bool, verbose: bool) -> Result<PathBuf, St
     if bytes == 0 {
         return Err("Empty file".to_string());
     }
-
     if verbose {
         println!("→ Downloaded {} bytes", bytes);
     }
 
     dest.canonicalize().or(Ok(dest))
-}
-
-fn dir_path(nsfw: bool) -> Result<PathBuf, String> {
-    let mut path = if cfg!(windows) {
-        let userprofile = std::env::var("USERPROFILE")
-            .or_else(|_| {
-                std::env::var("HOMEDRIVE").and_then(|drive| {
-                    std::env::var("HOMEPATH").map(|path| format!("{}{}", drive, path))
-                })
-            })
-            .map_err(|_| "User directory not found".to_string())?;
-        PathBuf::from(userprofile)
-    } else {
-        let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
-        PathBuf::from(home)
-    };
-
-    path.push("Pictures");
-    path.push("Parch");
-    if nsfw {
-        path.push("Nsfw");
-    }
-
-    create_dir_all(&path).map_err(|e| e.to_string())?;
-    Ok(path)
 }

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,32 +1,33 @@
+use crate::paths::parch_dir;
 use std::fs::read_dir;
 use std::path::PathBuf;
 
 pub fn get_random(nsfw: bool, verbose: bool) -> Result<PathBuf, String> {
-    let dir = dir_path(nsfw)?;
+    let dir = parch_dir(nsfw)?;
 
     if verbose {
         println!("→ Scanning directory: {}", dir.display());
     }
-
     if !dir.exists() {
         return Err(format!("Directory not found: {}", dir.display()));
     }
 
-    let mut images = Vec::new();
-
-    for entry in read_dir(&dir).map_err(|e| e.to_string())? {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let path = entry.path();
-
-        if path.is_file()
-            && let Some(ext) = path.extension()
-        {
-            let ext_lower = ext.to_string_lossy().to_lowercase();
-            if matches!(ext_lower.as_str(), "jpg" | "jpeg" | "png" | "bmp") {
-                images.push(path);
-            }
-        }
-    }
+    let mut images: Vec<PathBuf> = read_dir(&dir)
+        .map_err(|e| e.to_string())?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.is_file()
+                && p.extension()
+                    .map(|ext| {
+                        matches!(
+                            ext.to_string_lossy().to_lowercase().as_str(),
+                            "jpg" | "jpeg" | "png" | "bmp"
+                        )
+                    })
+                    .unwrap_or(false)
+        })
+        .collect();
 
     if images.is_empty() {
         return Err(format!(
@@ -40,7 +41,6 @@ pub fn get_random(nsfw: bool, verbose: bool) -> Result<PathBuf, String> {
         println!("→ Found {} wallpaper(s)", images.len());
     }
 
-    // Fast random selection using timestamp
     let idx = (std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -48,34 +48,9 @@ pub fn get_random(nsfw: bool, verbose: bool) -> Result<PathBuf, String> {
         % images.len();
 
     let selected = images.swap_remove(idx);
-
     if verbose {
         println!("→ Selected: {}", selected.display());
     }
 
     Ok(selected)
-}
-
-fn dir_path(nsfw: bool) -> Result<PathBuf, String> {
-    let mut path = if cfg!(windows) {
-        let userprofile = std::env::var("USERPROFILE")
-            .or_else(|_| {
-                std::env::var("HOMEDRIVE").and_then(|drive| {
-                    std::env::var("HOMEPATH").map(|path| format!("{}{}", drive, path))
-                })
-            })
-            .map_err(|_| "User directory not found".to_string())?;
-        PathBuf::from(userprofile)
-    } else {
-        let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
-        PathBuf::from(home)
-    };
-
-    path.push("Pictures");
-    path.push("Parch");
-    if nsfw {
-        path.push("Nsfw");
-    }
-
-    Ok(path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod cli;
 mod download;
 mod local;
+mod paths;
 mod wallpaper;
 
 fn main() {
@@ -15,29 +16,21 @@ fn run() -> Result<(), String> {
     let args = cli::parse()?;
 
     let path = if args.local {
-        // Use local wallpaper
         local::get_random(args.nsfw, args.verbose)?
     } else {
-        // Fetch from Konachan
-        let post = api::fetch(&args)?;
+        let post = api::fetch(args.id, args.nsfw, args.verbose)?;
         let url = api::image_url(&post)?;
-        let full_url = if url.starts_with("//") {
-            format!("https:{}", url)
-        } else if !url.starts_with("http") {
-            format!("https://{}", url)
-        } else {
-            url.to_string()
-        };
-
-        download::save(post.id, &full_url, post.rating == "e", args.verbose)?
+        download::save(post.id, &url, post.rating == "e", args.verbose)?
     };
 
     wallpaper::set(&path, args.verbose)?;
-
-    if args.verbose {
-        println!("✓ Wallpaper set successfully.");
-    } else {
-        println!("✓ Applied!");
-    }
+    println!(
+        "{}",
+        if args.verbose {
+            "✓ Wallpaper set successfully."
+        } else {
+            "✓ Applied!"
+        }
+    );
     Ok(())
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+pub fn parch_dir(nsfw: bool) -> Result<PathBuf, String> {
+    let mut path = if cfg!(windows) {
+        PathBuf::from(
+            std::env::var("USERPROFILE")
+                .or_else(|_| {
+                    std::env::var("HOMEDRIVE")
+                        .and_then(|d| std::env::var("HOMEPATH").map(|p| format!("{}{}", d, p)))
+                })
+                .map_err(|_| "User directory not found")?,
+        )
+    } else {
+        PathBuf::from(std::env::var("HOME").map_err(|_| "HOME not set")?)
+    };
+
+    path.push("Pictures");
+    path.push("Parch");
+    if nsfw {
+        path.push("Nsfw");
+    }
+    Ok(path)
+}


### PR DESCRIPTION
- api.rs: refactored fetch() to take (id, nsfw, verbose) instead of Args, simplified JSON parsing, and improved image_url() to normalize URLs with https://
- cli.rs: removed redundant NAME/VERSION consts in favor of env! macros, cleaned up argument parsing, unified error messages, and improved help text wording
- download.rs: replaced internal dir_path() with new parch_dir() from paths, ensured directories are created before saving, and improved verbose logging
- local.rs: simplified directory scanning with iterators, switched to parch_dir(), and removed duplicate dir_path() logic
- main.rs: cleaned up run() by removing redundant URL handling and improving verbose vs non-verbose success messages
- wallpaper.rs: inlined Windows wallpaper setting logic, merged KDE/GNOME/feh handling into a unified run() helper, normalized file:// URI handling, and simplified verbose logging
- general: removed duplication, centralized path handling, made CLI errors clearer, and reduced platform-specific code duplication